### PR TITLE
WIP: changed base docker image to be from rhel7

### DIFF
--- a/qdrouterd/Dockerfile
+++ b/qdrouterd/Dockerfile
@@ -1,6 +1,12 @@
-FROM gordons/qpid-proton:0.15.0
+FROM enmasseproject/qpid-proton:0.15.0
+
+RUN yum -y install \
+    gettext \
+    hostname \
+    iputils \
+    && yum clean all
+
 ADD qpid-dispatch-binary.tar.gz /
-RUN dnf -y install gettext hostname iputils
 COPY ./run_qdr.sh ./qdrouterd.conf.template colocated-topic.snippet ssl.snippet subscriptions.snippet amqp-kafka-bridge.snippet /etc/qpid-dispatch/
 
 EXPOSE 5672 55672 5671

--- a/qpid-proton/Dockerfile
+++ b/qpid-proton/Dockerfile
@@ -1,9 +1,18 @@
-FROM fedora:22
+FROM rhel7/rhel
 
-RUN dnf -y install cmake cyrus-sasl-devel gcc libuuid-devel make openssl-devel python-devel swig
+RUN yum -y install \
+    cmake \
+    cyrus-sasl-devel \
+    gcc libuuid-devel \
+    make \
+    openssl-devel \
+    python-devel \
+    swig \
+    && yum clean all
 
-ENV PROTON_VERSION 0.12.0
+ENV PROTON_VERSION 0.15.0
 ADD qpid-proton-$PROTON_VERSION.tar.gz /
+
 RUN mkdir /qpid-proton-$PROTON_VERSION/build
 WORKDIR /qpid-proton-$PROTON_VERSION/build
 


### PR DESCRIPTION
I created the image for qpid-proton, based off of rhel7, and pushed it to ce-registry.usersys.redhat.com/enmasseproject/qpid-proton:0.15.0.

Is there any box that will be building the qpid-qdrouterd image, and not be able to get it from the ce-registry?

