### PR TITLE
Updated Qpid Proton image to use 0.17.0 release

### DIFF
--- a/qdrouterd/Dockerfile
+++ b/qdrouterd/Dockerfile
@@ -1,4 +1,4 @@
-FROM gordons/qpid-proton:0.15.0
+FROM ppatierno/qpid-proton:0.17.0
 ADD qpid-dispatch-binary.tar.gz /
 RUN dnf -y install gettext hostname iputils
 COPY ./run_qdr.sh ./qdrouterd.conf.template colocated-topic.snippet ssl.snippet subscriptions.snippet amqp-kafka-bridge.snippet /etc/qpid-dispatch/

--- a/qdrouterd/build_tarball
+++ b/qdrouterd/build_tarball
@@ -8,7 +8,7 @@ MESH_PATCH=$BASE/meshfix.patch
 CONNDEBUG_PATCH=$BASE/connection_debug.patch
 
 wget ${1:-http://archive.apache.org/dist/qpid/dispatch/0.7.0/qpid-dispatch-0.7.0.tar.gz} -O qpid-dispatch.tar.gz
-wget ${2:-http://archive.apache.org/dist/qpid/proton/0.15.0/qpid-proton-0.15.0.tar.gz} -O qpid-proton.tar.gz
+wget ${2:-http://archive.apache.org/dist/qpid/proton/0.17.0/qpid-proton-0.17.0.tar.gz} -O qpid-proton.tar.gz
 
 mkdir qpid-dispatch-src qpid-proton-src build staging proton_build proton_install
 tar -zxf qpid-dispatch.tar.gz -C qpid-dispatch-src --strip-components 1

--- a/qpid-proton/Dockerfile
+++ b/qpid-proton/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:22
+FROM fedora:25
 
 RUN dnf -y install cmake cyrus-sasl-devel gcc libuuid-devel make openssl-devel python-devel swig
 
-ENV PROTON_VERSION 0.12.0
+ENV PROTON_VERSION 0.17.0
 ADD qpid-proton-$PROTON_VERSION.tar.gz /
 RUN mkdir /qpid-proton-$PROTON_VERSION/build
 WORKDIR /qpid-proton-$PROTON_VERSION/build


### PR DESCRIPTION
Updated Qpid Dispatch Router image to use above Qpid Proton 0.17.0 image and Fedora 25